### PR TITLE
get_workdays() 添加参数include_weekends

### DIFF
--- a/chinese_calendar/utils.py
+++ b/chinese_calendar/utils.py
@@ -129,16 +129,20 @@ def get_holidays(start, end, include_weekends=True):
     return list(filter(lambda x: x in holidays, get_dates(start, end)))
 
 
-def get_workdays(start, end):
+def get_workdays(start, end, include_weekends=True):
     """
     get workdays between start date and end date. (includes start date and end date)
 
     :type start: datetime.date | datetime.datetime
     :type end:  datetime.date | datetime.datetime
+    :type include_weekends: bool
+    :param include_weekends: False for excluding Saturdays and Sundays
     :rtype: list[datetime.date]
     """
     start, end = _validate_date(start, end)
-    return list(filter(is_workday, get_dates(start, end)))
+    if include_weekends:
+        return list(filter(is_workday, get_dates(start, end)))
+    return list(filter(lambda x: is_workday(x) and x.weekday() < 5, get_dates(start, end)))
 
 
 def find_workday(delta_days=0, date=None):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -25,16 +25,25 @@ class HelperTests(unittest.TestCase):
 
     def test_get_workdays_holidays(self):
         cases = [
-            ((2018, 2, 1), (2018, 1, 1), 0, 0, 0),
-            ((2018, 1, 1), (2018, 1, 1), 1, 1, 0),
-            ((2018, 1, 1), (2018, 1, 7), 3, 1, 4),
-            ((2018, 1, 1), (2018, 2, 1), 9, 1, 23),
+            ((2018, 2, 1), (2018, 1, 1), 0, 0, 0, 0),
+            ((2018, 1, 1), (2018, 1, 1), 1, 1, 0, 0),
+            ((2018, 1, 1), (2018, 1, 7), 3, 1, 4, 4),
+            ((2018, 1, 1), (2018, 2, 1), 9, 1, 23, 23),
+            ((2018, 2, 1), (2018, 3, 1), 11, 7, 18, 16),
         ]
-        for start, end, include_weekends, exclude_weekends, workdays in cases:
+        for (start, end, include_weekends, exclude_weekends, workdays,
+             workdays_exclude_weekends) in cases:
             start, end = datetime.date(*start), datetime.date(*end)
             self.assertEqual(include_weekends, len(chinese_calendar.get_holidays(start, end)))
-            self.assertEqual(exclude_weekends, len(chinese_calendar.get_holidays(start, end, include_weekends=False)))
+            self.assertEqual(
+                exclude_weekends,
+                len(chinese_calendar.get_holidays(start, end, include_weekends=False))
+            )
             self.assertEqual(workdays, len(chinese_calendar.get_workdays(start, end)))
+            self.assertEqual(
+                workdays_exclude_weekends,
+                len(chinese_calendar.get_workdays(start, end, include_weekends=False))
+            )
 
     def test_find_workday(self):
         dates = [


### PR DESCRIPTION
get_workdays()添加该参数后会进一步过滤掉调休的周末。在某些场合，比如基金数据，工作日是不包含调休的周末的。
我添加里对应的测试用例。