### PR TITLE
fix 23-24 元旦假期

### DIFF
--- a/chinese_calendar/constants.py
+++ b/chinese_calendar/constants.py
@@ -558,6 +558,8 @@ holidays = {
     datetime.date(year=2023, month=10, day=4): Holiday.national_day.value,
     datetime.date(year=2023, month=10, day=5): Holiday.national_day.value,
     datetime.date(year=2023, month=10, day=6): Holiday.national_day.value,
+    datetime.date(year=2023, month=12, day=30): Holiday.new_years_day.value,
+    datetime.date(year=2023, month=12, day=31): Holiday.new_years_day.value,
     datetime.date(year=2024, month=1, day=1): Holiday.new_years_day.value,
     datetime.date(year=2024, month=2, day=10): Holiday.spring_festival.value,
     datetime.date(year=2024, month=2, day=11): Holiday.spring_festival.value,

--- a/chinese_calendar/scripts/data.py
+++ b/chinese_calendar/scripts/data.py
@@ -101,7 +101,8 @@ class Arrangement(object):
             .ld().rest(4, 29).to(5, 3).work(4, 23).work(5, 6).in_lieu(5, 2).to(5, 3) \
             .dbf().rest(6, 22).to(6, 24).work(6, 25).in_lieu(6, 23) \
             .maf().rest(9, 29) \
-            .nd().rest(9, 30).to(10, 6).work(10, 7).to(10, 8).in_lieu(10, 5).to(10, 6)
+            .nd().rest(9, 30).to(10, 6).work(10, 7).to(10, 8).in_lieu(10, 5).to(10, 6)\
+            .nyd().rest(12, 30).to(12, 31)
 
     def _2022(self):
         """ http://www.gov.cn/zhengce/content/2021-10/25/content_5644835.htm


### PR DESCRIPTION
23-24年 元旦假期 里 23-12-30 和23-12-31 应该都算做元旦假期 而不是普通的周末